### PR TITLE
Replace slacker with a small built-in Slack client

### DIFF
--- a/deslackify/cli.py
+++ b/deslackify/cli.py
@@ -12,9 +12,8 @@ import urllib.parse
 from collections import Counter
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any
 
-import slacker  # pyright: ignore[reportMissingTypeStubs]
 from requests import HTTPError, ReadTimeout, Session
 
 if TYPE_CHECKING:
@@ -25,62 +24,62 @@ try:
 except PackageNotFoundError:
     __version__ = "unknown"
 
+API_BASE_URL = "https://slack.com/api/"
 MAX_RETRIES = 5
 MAX_SLEEP_SECONDS = 3
 READ_TIMEOUT_SLEEP_SECONDS = 16
+REQUEST_TIMEOUT = 30
 TOO_MANY_REQUESTS = 429
 
 logger = logging.getLogger(__name__)
-
-
-class Chat(Protocol):
-    """The ``chat`` methods of :class:`slacker.Slacker` used here."""
-
-    def delete(self, *, as_user: bool, channel: str, ts: str) -> Response:
-        """Delete the message identified by ``ts`` in ``channel``."""
-        ...
-
-    def update(self, *, as_user: bool, channel: str, text: str, ts: str) -> Response:
-        """Replace the text of the message identified by ``ts`` in ``channel``."""
-        ...
-
-
-class Response(Protocol):
-    """The subset of a :class:`slacker.Response` that this program relies on."""
-
-    body: Mapping[str, Any]
-    successful: bool
 
 
 class RetryError(Exception):
     """Raised when a request does not succeed within ``MAX_RETRIES`` attempts."""
 
 
-class Search(Protocol):
-    """The ``search`` methods of :class:`slacker.Slacker` used here."""
+class SlackClient:
+    """A minimal Slack Web API client backed by a :class:`requests.Session`.
 
-    def messages(self, *, count: int, page: int, query: str, sort: str, sort_dir: str) -> Response:
-        """Return a page of messages matching ``query``."""
-        ...
+    The token is sent as a bearer header, which authenticates both ``xoxp-`` app tokens
+    and ``xoxc-`` browser tokens (the latter paired with a ``d`` cookie).
+
+    """
+
+    def __init__(self, token: str, cookie: str | None) -> None:
+        """Build a client authenticating with ``token`` and an optional ``cookie``."""
+        self._token = token
+        self._session = _session(cookie)
+
+    def _request(self, method: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        response = self._session.post(
+            f"{API_BASE_URL}{method}",
+            data=dict(params),
+            headers={"Authorization": f"Bearer {self._token}"},
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        body: dict[str, Any] = response.json()
+        if not body["ok"]:
+            raise SlackError(body["error"])
+        return body
+
+    def call(self, method: str, **params: Any) -> Mapping[str, Any]:
+        """Call Slack Web API ``method``, retrying on rate limits and timeouts.
+
+        Returns:
+            The decoded ``ok: true`` response body.
+
+        """
+        return handle_rate_limit(lambda: self._request(method, params))
 
 
-class Slack(Protocol):
-    """The subset of :class:`slacker.Slacker` that this program relies on."""
-
-    chat: Chat
-    search: Search
-
-
-def _attempt(method: Callable[..., Response], kwargs: Mapping[str, Any]) -> Response:
-    response = method(**kwargs)
-    if not response.successful or not response.body["ok"]:
-        message = "Slack reported an unsuccessful response"
-        raise RuntimeError(message)
-    return response
+class SlackError(Exception):
+    """Raised when the Slack API returns an unsuccessful (``ok: false``) response."""
 
 
 def _handle_message(
-    slack: Slack, message: Mapping[str, Any], args: argparse.Namespace, errors: Counter[str]
+    client: SlackClient, message: Mapping[str, Any], args: argparse.Namespace, errors: Counter[str]
 ) -> int:
     when = datetime.fromtimestamp(int(message["ts"].split(".", 1)[0]), tz=timezone.utc).strftime(
         "%Y-%m-%d %H:%M:%S"
@@ -88,15 +87,13 @@ def _handle_message(
     logger.info("%s %s", when, message["text"])
     try:
         if not args.dry_run:
-            delete_message(slack, message, update_first=args.update)
+            delete_message(client, message, update_first=args.update)
     except RetryError:
         errors["max retries exceeded"] += 1
         logger.warning("RetryError")
-    except slacker.Error as exception:
-        if len(exception.args) != 1:
-            raise
-        errors[exception.args[0]] += 1
-        logger.warning(exception.args[0])
+    except SlackError as exception:
+        errors[str(exception)] += 1
+        logger.warning("%s", exception)
         return 0
     return 1
 
@@ -129,26 +126,26 @@ def _session(cookie: str | None) -> Session:
     return session
 
 
-def delete_message(slack: Slack, message: Mapping[str, Any], *, update_first: bool = False) -> None:
+def delete_message(
+    client: SlackClient, message: Mapping[str, Any], *, update_first: bool = False
+) -> None:
     """Delete ``message``, optionally overwriting its text with ``-`` beforehand."""
     channel = message["channel"]["id"]
     if update_first:
-        handle_rate_limit(
-            slack.chat.update, as_user=True, channel=channel, text="-", ts=message["ts"]
-        )
-    handle_rate_limit(slack.chat.delete, as_user=True, channel=channel, ts=message["ts"])
+        client.call("chat.update", as_user="true", channel=channel, text="-", ts=message["ts"])
+    client.call("chat.delete", as_user="true", channel=channel, ts=message["ts"])
 
 
-def handle_rate_limit(method: Callable[..., Response], **kwargs: Any) -> Response:
-    """Call ``method``, retrying when Slack rate-limits or times out.
+def handle_rate_limit(call: Callable[[], Mapping[str, Any]]) -> Mapping[str, Any]:
+    """Invoke ``call``, retrying when Slack rate-limits or times out.
 
     Returns:
-        The successful :class:`Response`.
+        The result of ``call``.
 
     """
     for _ in range(MAX_RETRIES):
         try:
-            return _attempt(method, kwargs)
+            return call()
         except HTTPError as exception:
             response = exception.response
             if response is None or response.status_code != TOO_MANY_REQUESTS:
@@ -230,12 +227,11 @@ def main() -> int:
         )
         return 1
 
-    with _session(args.cookie or os.getenv("SLACK_COOKIE")) as session:
-        slack = cast("Slack", slacker.Slacker(token, session=session))
-        return run(slack, args)
+    client = SlackClient(token, args.cookie or os.getenv("SLACK_COOKIE"))
+    return run(client, args)
 
 
-def run(slack: Slack, args: argparse.Namespace) -> int:
+def run(client: SlackClient, args: argparse.Namespace) -> int:
     """Search for and delete the messages described by ``args``.
 
     Returns:
@@ -246,8 +242,8 @@ def run(slack: Slack, args: argparse.Namespace) -> int:
     errors: Counter[str] = Counter()
 
     try:
-        for message in search_messages(slack, args.user, after=args.after, before=args.before):
-            deleted += _handle_message(slack, message, args, errors)
+        for message in search_messages(client, args.user, after=args.after, before=args.before):
+            deleted += _handle_message(client, message, args, errors)
     except KeyboardInterrupt:
         pass
 
@@ -259,7 +255,7 @@ def run(slack: Slack, args: argparse.Namespace) -> int:
 
 
 def search_messages(
-    slack: Slack, user: str, *, after: str | None, before: str
+    client: SlackClient, user: str, *, after: str | None, before: str
 ) -> Iterator[Mapping[str, Any]]:
     """Yield messages sent by ``user`` within the requested date range.
 
@@ -279,13 +275,11 @@ def search_messages(
         "sort": "timestamp",
         "sort_dir": "desc",
     }
-    response = handle_rate_limit(slack.search.messages, page=1, **search_params)
-    result = response.body["messages"]
+    result = client.call("search.messages", page=1, **search_params)["messages"]
     page = result["paging"]["pages"]
     logger.info("Found %d items", result["total"])
 
     while page > 0:
-        response = handle_rate_limit(slack.search.messages, page=page, **search_params)
-        result = response.body["messages"]
+        result = client.call("search.messages", page=page, **search_params)["messages"]
         yield from sorted(result["matches"], key=operator.itemgetter("ts"))
         page -= 1

--- a/deslackify/cli.py
+++ b/deslackify/cli.py
@@ -6,11 +6,12 @@ import argparse
 import logging
 import operator
 import os
+import re
 import sys
 import time
 import urllib.parse
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any
 
@@ -96,6 +97,16 @@ def _handle_message(
         logger.warning("%s", exception)
         return 0
     return 1
+
+
+def _is_valid_date(value: str) -> bool:
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", value) is None:
+        return False
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
 
 
 def _normalize_d_cookie(cookie: str) -> str:
@@ -186,7 +197,7 @@ def main() -> int:
     parser.add_argument(
         "--before",
         default=default_before.strftime("%Y-%m-%d"),
-        help="Date to delete messages prior to (default: %(default)s)",
+        help="Date (YYYY-MM-DD) to delete messages prior to (default: %(default)s)",
     )
     parser.add_argument(
         "--cookie",
@@ -215,6 +226,11 @@ def main() -> int:
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     args = parser.parse_args()
+
+    for flag, value in (("--after", args.after), ("--before", args.before)):
+        if value is not None and not _is_valid_date(value):
+            sys.stderr.write(f"The {flag} value must be a date in YYYY-MM-DD format\n")
+            return 1
 
     if args.after and args.after >= args.before:
         sys.stderr.write("The --after value must be older than the --before value\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14"
 ]
 dependencies = [
-  "requests >=2.20",
-  "slacker >=0.12, <0.13"
+  "requests >=2.20"
 ]
 description = "A program to delete old slack messages."
 dynamic = ["version"]

--- a/tests/test_deslackify.py
+++ b/tests/test_deslackify.py
@@ -1,11 +1,23 @@
 import argparse
 
 import pytest
-import slacker
 from requests import HTTPError
 
 import deslackify
 from deslackify import cli
+
+
+class FakeClient:
+    def __init__(self, responses=None):
+        self.calls = []
+        self._responses = responses or {}
+
+    def call(self, method, **params):
+        self.calls.append((method, params))
+        result = self._responses.get(method)
+        if isinstance(result, Exception):
+            raise result
+        return result if result is not None else {"ok": True}
 
 
 class FakeHTTPResponse:
@@ -14,10 +26,25 @@ class FakeHTTPResponse:
         self.headers = headers or {}
 
 
-class FakeResponse:
-    def __init__(self, body=None, *, successful=True):
-        self.body = {"ok": True} if body is None else body
-        self.successful = successful
+class FakePostResponse:
+    def __init__(self, body):
+        self._body = body
+
+    def json(self):
+        return self._body
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeSession:
+    def __init__(self, body):
+        self._body = body
+        self.posted = []
+
+    def post(self, url, **kwargs):
+        self.posted.append((url, kwargs))
+        return FakePostResponse(self._body)
 
 
 @pytest.fixture(autouse=True)
@@ -29,79 +56,73 @@ def http_error(status_code, *, retry_after="0"):
     return HTTPError(response=FakeHTTPResponse(status_code, {"retry-after": retry_after}))
 
 
+def test_client_call_posts_bearer_token_and_returns_body():
+    client = cli.SlackClient("xoxc-tok", None)
+    client._session = FakeSession({"ok": True, "value": 1})
+    assert client.call("search.messages", query="q") == {"ok": True, "value": 1}
+    url, kwargs = client._session.posted[0]
+    assert url == "https://slack.com/api/search.messages"
+    assert kwargs["headers"]["Authorization"] == "Bearer xoxc-tok"
+    assert kwargs["data"] == {"query": "q"}
+
+
+def test_client_call_raises_slack_error_when_not_ok():
+    client = cli.SlackClient("tok", None)
+    client._session = FakeSession({"error": "cant_delete_message", "ok": False})
+    with pytest.raises(cli.SlackError, match="cant_delete_message"):
+        client.call("chat.delete", ts="1")
+
+
 def test_delete_message_delete_only():
-    calls = []
-
-    class FakeChat:
-        def delete(self, **kwargs):
-            calls.append("delete")
-            return FakeResponse()
-
-    class FakeSlack:
-        chat = FakeChat()
-
-    cli.delete_message(FakeSlack(), {"channel": {"id": "C1"}, "ts": "1"})
-    assert calls == ["delete"]
+    client = FakeClient()
+    cli.delete_message(client, {"channel": {"id": "C1"}, "ts": "1"})
+    assert [method for method, _ in client.calls] == ["chat.delete"]
 
 
 def test_delete_message_updates_then_deletes():
-    calls = []
-
-    class FakeChat:
-        def update(self, **kwargs):
-            calls.append(("update", kwargs))
-            return FakeResponse()
-
-        def delete(self, **kwargs):
-            calls.append(("delete", kwargs))
-            return FakeResponse()
-
-    class FakeSlack:
-        chat = FakeChat()
-
-    message = {"channel": {"id": "C1"}, "ts": "123"}
-    cli.delete_message(FakeSlack(), message, update_first=True)
-    assert [name for name, _ in calls] == ["update", "delete"]
-    assert calls[0][1] == {"as_user": True, "channel": "C1", "text": "-", "ts": "123"}
+    client = FakeClient()
+    cli.delete_message(client, {"channel": {"id": "C1"}, "ts": "123"}, update_first=True)
+    assert [method for method, _ in client.calls] == ["chat.update", "chat.delete"]
+    assert client.calls[0][1] == {
+        "as_user": "true",
+        "channel": "C1",
+        "text": "-",
+        "ts": "123",
+    }
 
 
 def test_handle_rate_limit_gives_up():
-    def method():
+    def call():
         raise http_error(429)
 
     with pytest.raises(cli.RetryError):
-        cli.handle_rate_limit(method)
+        cli.handle_rate_limit(call)
 
 
 def test_handle_rate_limit_reraises_other_http_errors():
-    def method():
+    def call():
         raise http_error(500)
 
     with pytest.raises(HTTPError):
-        cli.handle_rate_limit(method)
+        cli.handle_rate_limit(call)
 
 
 def test_handle_rate_limit_retries_then_succeeds():
-    outcomes = [http_error(429), FakeResponse()]
+    outcomes = [http_error(429), {"ok": True}]
 
-    def method():
+    def call():
         outcome = outcomes.pop(0)
         if isinstance(outcome, Exception):
             raise outcome
         return outcome
 
-    assert cli.handle_rate_limit(method).body["ok"] is True
+    assert cli.handle_rate_limit(call) == {"ok": True}
     assert outcomes == []
 
 
 def test_handle_rate_limit_success():
-    response = FakeResponse()
-    assert cli.handle_rate_limit(lambda: response) is response
-
-
-def test_handle_rate_limit_unsuccessful_raises():
-    with pytest.raises(RuntimeError):
-        cli.handle_rate_limit(lambda: FakeResponse(successful=False))
+    body = {"ok": True}
+    assert cli.handle_rate_limit(lambda: body) is body
 
 
 def test_normalize_d_cookie_encodes_decoded_value():
@@ -117,20 +138,16 @@ def test_normalize_d_cookie_is_idempotent_on_encoded_value():
     assert cli._normalize_d_cookie("xoxd-a%2Fb%2Bc") == "xoxd-a%2Fb%2Bc"
 
 
-def test_run_counts_slacker_errors(monkeypatch):
+def test_run_counts_slack_errors(monkeypatch):
     message = {"channel": {"id": "C1"}, "text": "hello", "ts": "1609459200.000"}
     monkeypatch.setattr(cli, "search_messages", lambda *_a, **_k: iter([message]))
 
     def raise_error(*_args, **_kwargs):
-        raise slacker.Error("cant_delete_message")
+        raise cli.SlackError("cant_delete_message")
 
     monkeypatch.setattr(cli, "delete_message", raise_error)
     args = argparse.Namespace(
-        after=None,
-        before="2021-01-01",
-        dry_run=False,
-        update=False,
-        user="alice",
+        after=None, before="2021-01-01", dry_run=False, update=False, user="alice"
     )
     assert cli.run(object(), args) == 0
 
@@ -141,59 +158,32 @@ def test_run_dry_run_does_not_delete(monkeypatch):
     deleted = []
     monkeypatch.setattr(cli, "delete_message", lambda *a, **k: deleted.append(True))
     args = argparse.Namespace(
-        after=None,
-        before="2021-01-01",
-        dry_run=True,
-        update=False,
-        user="alice",
+        after=None, before="2021-01-01", dry_run=True, update=False, user="alice"
     )
     assert cli.run(object(), args) == 0
     assert deleted == []
 
 
 def test_search_messages_builds_query_and_paginates():
-    captured = []
-
-    class FakeSearch:
-        def messages(self, **kwargs):
-            captured.append(kwargs)
-            return FakeResponse({
-                "messages": {
-                    "matches": [{"ts": "2"}, {"ts": "1"}],
-                    "paging": {"pages": 2},
-                    "total": 3,
-                },
-                "ok": True,
-            })
-
-    class FakeSlack:
-        search = FakeSearch()
-
-    results = list(
-        cli.search_messages(FakeSlack(), "alice", after="2020-01-01", before="2021-01-01"),
-    )
-    assert captured[0]["query"] == "from:alice after:2020-01-01 before:2021-01-01"
+    body = {
+        "messages": {
+            "matches": [{"ts": "2"}, {"ts": "1"}],
+            "paging": {"pages": 2},
+            "total": 3,
+        },
+        "ok": True,
+    }
+    client = FakeClient({"search.messages": body})
+    results = list(cli.search_messages(client, "alice", after="2020-01-01", before="2021-01-01"))
+    assert client.calls[0][1]["query"] == "from:alice after:2020-01-01 before:2021-01-01"
     assert [match["ts"] for match in results] == ["1", "2", "1", "2"]
 
 
 def test_search_messages_without_after():
-    class FakeSearch:
-        def messages(self, **kwargs):
-            self.query = kwargs["query"]
-            return FakeResponse({
-                "messages": {"matches": [], "paging": {"pages": 0}, "total": 0},
-                "ok": True,
-            })
-
-    search = FakeSearch()
-
-    class FakeSlack:
-        pass
-
-    slack = FakeSlack()
-    slack.search = search
-    assert list(cli.search_messages(slack, "bob", after=None, before="x")) == []
-    assert search.query == "from:bob before:x"
+    body = {"messages": {"matches": [], "paging": {"pages": 0}, "total": 0}, "ok": True}
+    client = FakeClient({"search.messages": body})
+    assert list(cli.search_messages(client, "bob", after=None, before="x")) == []
+    assert client.calls[0][1]["query"] == "from:bob before:x"
 
 
 def test_session_sets_encoded_d_cookie():

--- a/tests/test_deslackify.py
+++ b/tests/test_deslackify.py
@@ -125,6 +125,29 @@ def test_handle_rate_limit_success():
     assert cli.handle_rate_limit(lambda: body) is body
 
 
+@pytest.mark.parametrize("value", ["2026-06-15", "2020-01-01", "1999-12-31"])
+def test_is_valid_date_accepts_iso_dates(value):
+    assert cli._is_valid_date(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-6-15",  # not zero-padded
+        "06/14/2026",  # slash format
+        "20260615",  # no separators
+        "2026-06-15T00:00:00",  # includes a time
+        "yesterday",  # relative word
+        "1 hour ago",  # relative phrase
+        "2026-13-01",  # invalid month
+        "2026-06-32",  # invalid day
+        "",  # empty
+    ],
+)
+def test_is_valid_date_rejects_non_iso_values(value):
+    assert cli._is_valid_date(value) is False
+
+
 def test_normalize_d_cookie_encodes_decoded_value():
     assert cli._normalize_d_cookie("xoxd-a/b+c") == "xoxd-a%2Fb%2Bc"
 

--- a/uv.lock
+++ b/uv.lock
@@ -130,7 +130,6 @@ name = "deslackify"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },
-    { name = "slacker" },
 ]
 
 [package.dev-dependencies]
@@ -142,10 +141,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "requests", specifier = ">=2.20" },
-    { name = "slacker", specifier = ">=0.12,<0.13" },
-]
+requires-dist = [{ name = "requests", specifier = ">=2.20" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pyright" }]
@@ -261,18 +257,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
-]
-
-[[package]]
-name = "slacker"
-version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/7a/ad13ee89fe30ac69461ee7a3dee0882b493c8ce59b68a489948b50ac0403/slacker-0.12.0.tar.gz", hash = "sha256:7771d4edd2bf651f849b9ca84e54a9d343de4fd7a87fa8d31b872407441a4812", size = 9471, upload-time = "2018-12-08T11:23:27.692Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/c5/006794554034d01c7821171a5f2fe3b233f3261d7af76abbfdb0d69f1ce8/slacker-0.12.0-py3-none-any.whl", hash = "sha256:41ee24d0f28612542f9239b08d9936d0dee661d2a14e83d741037cb15fdf4ff4", size = 8726, upload-time = "2018-12-08T11:23:25.542Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`deslackify` only uses **three** Slack Web API methods — `search.messages`, `chat.delete`, `chat.update` — so depending on the unmaintained `slacker` library (last released 2020) isn't worth it. This implements them directly over `requests` (already a dependency).

## Changes
- **`SlackClient`** (token + optional `d` cookie) POSTs to the Slack Web API with the token in an `Authorization: Bearer` header — verified to authenticate both `xoxp-` app tokens and `xoxc-` browser tokens.
- **`SlackError`** replaces `slacker.Error`; the rate-limit/timeout retry loop is unchanged (`handle_rate_limit` now takes a plain callable).
- **Drops the `slacker` dependency** and the hand-rolled `Protocol` type shims it needed — pyright strict now runs against real types, and the `# pyright: ignore[reportMissingTypeStubs]` is gone.
- The `--cookie`/`_normalize_d_cookie` browser-session support is retained as-is.
- **Strict `--after`/`--before` validation** — only `YYYY-MM-DD` is accepted; times, relative phrases (`1 hour ago`), and unrecognized words are rejected with a clear error instead of silently matching the wrong messages (Slack's date modifiers mishandle them without erroring).
- Tests updated for the client-based API + the date validation (30 tests).

## Verification (live workspace, end-to-end)
- **Read path:** `--dry-run` found the expected messages via `search.messages`.
- **Write path:** ran a real `--update` delete of 4 throwaway messages → `Messages deleted: 4`, zero errors, and the search count drained to `0` — so both `chat.update` and `chat.delete` are confirmed working through the new client.
- **Validation:** `--after "1 hour ago"` and invalid dates are rejected before any API call.

pyright strict clean; pre-commit clean; CI green.