### PR TITLE
Use reusable python-ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,28 +8,5 @@ on:
 permissions: {}
 
 jobs:
-  lint:
-    name: Lint and type-check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0 # hatch-vcs needs tags to build the project for pyright
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - run: uvx pre-commit run --all-files
-        env:
-          SKIP: no-commit-to-branch # this guard is local-only; CI runs on main
-
-  test:
-    name: Test on Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0 # hatch-vcs needs tags to build the project
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - run: uv run --python ${{ matrix.python-version }} --group test pytest
+  ci:
+    uses: bboe/.github/.github/workflows/python-ci.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
   pull_request:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   ci:


### PR DESCRIPTION
Replaces the standalone CI with a thin caller of the new reusable `bboe/.github` `python-ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)